### PR TITLE
feat: added test for integer argument for set_timeout and fixed bug in actor

### DIFF
--- a/modular/phases/actor.py
+++ b/modular/phases/actor.py
@@ -68,7 +68,7 @@ def create_function_call_log_message(
 
     message_parts.append(function_call_message)
     if function_call_args:
-        message_parts.append(str(function_call_args))
+        message_parts.append(json.dumps(function_call_args))
     message = "\n".join(message_parts)
     return message, style
 

--- a/modular/phases/actor.py
+++ b/modular/phases/actor.py
@@ -68,7 +68,7 @@ def create_function_call_log_message(
 
     message_parts.append(function_call_message)
     if function_call_args:
-        message_parts.append(function_call_args)
+        message_parts.append(str(function_call_args))
     message = "\n".join(message_parts)
     return message, style
 


### PR DESCRIPTION
This bug causes the actor to crash when set_timeout is called with an integer argument. This adds a test to reproduce it and fixes the bug. 

See issue here: https://mp4-server.koi-moth.ts.net/run/#300696